### PR TITLE
Use `jsesc` instead of `string-escape`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var browserify = require('browserify')
 var through = require('through')
 var falafel = require('falafel')
-var strescape = require('string-escape')
+var strescape = require('jsesc')
 var path = require('path')
 var fs = require('fs')
 

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "start": "cd example && ./node_modules/.bin/beefy index.js 8080 -- -t workerify"
   },
   "dependencies": {
-    "through": "~2.3.4",
     "browserify": "~2.18.1",
-    "string-escape": "~0.1.6",
-    "falafel": "~0.2.1"
+    "falafel": "~0.2.1",
+    "jsesc": "~0.3.0",
+    "through": "~2.3.4"
   },
   "devDependencies": {
     "beefy": "~0.4.0",


### PR DESCRIPTION
The `string-escape` package has been renamed to `jsesc`. This patch updates the dependency.

For now the old `string-escape` package is still available as a mirror, but it might be removed in the future.

Please publish a new version of your package after merging this. Sorry for the inconvenience, and thanks!
