### PR TITLE
using uglify-js to minify worker blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ npm install workerify
 ```
 
 ## release history
+* 0.2.4 - using [uglify-js](https://github.com/mishoo/UglifyJS2) to minify worker blob (@skratchdot)
 * 0.2.3 - support compilation from coffeescript original source file
 * 0.2.2 - string-escape dep renamed to jsesc (@mathiasbynens)
 * 0.2.1 - Add missing falafel dep and bug fixes (@mikolalysenko)

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var falafel = require('falafel')
 var strescape = require('jsesc')
 var path = require('path')
 var fs = require('fs')
+var UglifyJS = require('uglify-js')
 
 var cwd = process.cwd()
 
@@ -109,5 +110,5 @@ function bfy(entry, done) {
   b.add(path.join(cwd, entry))
   var bundle = b.bundle()
   bundle.on('data', function(buf) { data += buf })
-  bundle.on('close', function() { done(null, data) })
+  bundle.on('close', function() { done(null, UglifyJS.minify(data, {fromString: true}).code) })
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workerify",
   "description": "Transform web workers into browserified inline Blobs with browserify.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "homepage": "https://github.com/shama/workerify",
   "author": {
     "name": "Kyle Robinson Young",
@@ -38,7 +38,8 @@
     "browserify": "~2.18.1",
     "falafel": "~0.2.1",
     "jsesc": "~0.3.0",
-    "through": "~2.3.4"
+    "through": "~2.3.4",
+    "uglify-js": "~2.4.8"
   },
   "devDependencies": {
     "beefy": "~0.4.0",


### PR DESCRIPTION
This saves a lot of space in my local testing.  I couldn't get "npm test" or "npm start" to work before or after my changes, but I did test that this works in another private repo that I have.

Feel free to close this pull request out if it's not the place for it.

I was having a very difficult time getting the worker blob to be minified via existing transforms, etc, so decided to make this change.
