### PR TITLE
- added fix/workaround for older webkit browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function isWorkerifyKeyword(node) {
 }
 
 function makeBlob(str, withWorker) {
-  var src = 'window.URL.createObjectURL(new Blob([""],{type:"text/javascript"}))'
+  var src = '(window.webkitURL || window.URL).createObjectURL(new Blob([""],{type:"text/javascript"}))'
   if (withWorker === true) src = 'new Worker(' + src + ')'
   return falafel(src, function(node) {
     if (node.type === 'Literal' && node.value === '') {


### PR DESCRIPTION
Hello, this is just  a quick fix for issue #14, in order to have workerified script work in older webkit browsers.
Tests run ok, and manually tested in an older Chrome (31.0.1650.57). Where I had the issue.

Cheers!
